### PR TITLE
Admin order

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,12 +1,17 @@
 class Admin::DashboardController < Admin::BaseController
 
   def index
-    @orders = all_orders
+    @orders = choose_orders
   end
 
   private
 
-  def all_orders
-    @orders = Order.all
+  def choose_orders
+    if order_filter = params[:order_type]
+      @orders = Order.where(status: order_filter)
+    else
+      @orders = Order.all
+    end
   end
+
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,12 @@
 class Admin::DashboardController < Admin::BaseController
 
   def index
-    
+    @orders = all_orders
   end
 
+  private
+
+  def all_orders
+    @orders = Order.all
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,10 @@
+class Admin::OrdersController < Admin::BaseController
+
+  def cancel
+    order = Order.find(params[:format])
+    order.update(status: "Cancelled")
+    
+    redirect_to admin_dashboard_path
+  end
+
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,9 +1,9 @@
 class Admin::OrdersController < Admin::BaseController
 
-  def cancel
+  def modify
     order = Order.find(params[:format])
-    order.update(status: "Cancelled")
-    
+    order.change_status(params[:modify_type])
+
     redirect_to admin_dashboard_path
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,4 +8,15 @@ class Order < ApplicationRecord
   end
 
   enum status: status_types
+
+  def change_status(new_status)
+    case new_status
+    when "cancel"
+      update(status: "Cancelled")
+    when "mark as paid"
+      update(status: "Paid")
+    when "mark as completed"
+      update(status: "Completed")
+    end
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,11 @@
 class Order < ApplicationRecord
-  enum status: ["ordered", "paid", "cancelled", "shipped"]
 
   has_many :order_items
   has_many :items, through: :order_items
+
+  def self.status_types
+    ["Ordered", "Paid", "Cancelled", "Completed"]
+  end
+
+  enum status: status_types
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,1 +1,3 @@
 <h4>Admin Dashboard</h4>
+
+<%= render partial: 'shared/order_list' %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,3 +1,7 @@
 <h4>Admin Dashboard</h4>
 
+<% @orders.status_types.each do |type| %>
+  <span><%= link_to type, admin_dashboard_path(order_type: type) %></span>
+<% end %>
+
 <%= render partial: 'shared/order_list' %>

--- a/app/views/shared/_order_actions.html.erb
+++ b/app/views/shared/_order_actions.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Cancel", admin_cancel_order_path(order), method: :post %>

--- a/app/views/shared/_order_actions.html.erb
+++ b/app/views/shared/_order_actions.html.erb
@@ -1,1 +1,8 @@
-<%= link_to "Cancel", admin_cancel_order_path(order), method: :post %>
+<% case order.status %>
+<% when "Ordered" %>
+  <%= link_to "Cancel", admin_modify_order_path(order, modify_type: "cancel"), method: :post %>
+  <%= link_to "Mark As Paid", admin_modify_order_path(order, modify_type: "mark as paid"), method: :post %>
+<% when "Paid" %>
+  <%= link_to "Cancel", admin_modify_order_path(order, modify_type: "cancel"), method: :post %>
+  <%= link_to "Mark As Completed", admin_modify_order_path(order, modify_type: "mark as completed"), method: :post %>
+<% end %>

--- a/app/views/shared/_order_actions.html.erb
+++ b/app/views/shared/_order_actions.html.erb
@@ -3,6 +3,6 @@
   <%= link_to "Cancel", admin_modify_order_path(order, modify_type: "cancel"), method: :post %>
   <%= link_to "Mark As Paid", admin_modify_order_path(order, modify_type: "mark as paid"), method: :post %>
 <% when "Paid" %>
-  <%= link_to "Cancel", admin_modify_order_path(order, modify_type: "cancel"), method: :post %>
+  <%= link_to "Cancel", admin_modify_order_path(order, modify_type: "cancel"), method: :post %>  
   <%= link_to "Mark As Completed", admin_modify_order_path(order, modify_type: "mark as completed"), method: :post %>
 <% end %>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -2,7 +2,7 @@
   <% @orders.each do |order| %>
     <li>
       <%= link_to "Order ##{order.id}" %> - Status: <%= order.status %>
-      <%= link_to "Cancel", admin_cancel_order_path(order), method: :post %>
+      <%= (render partial: "shared/order_actions", locals: { order: order }) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -2,6 +2,7 @@
   <% @orders.each do |order| %>
     <li>
       <%= link_to "Order ##{order.id}" %> - Status: <%= order.status %>
+      <br>
       <%= (render partial: "shared/order_actions", locals: { order: order }) %>
     </li>
   <% end %>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -2,6 +2,7 @@
   <% @orders.each do |order| %>
     <li>
       <%= link_to "Order ##{order.id}" %> - Status: <%= order.status %>
+      <%= link_to "Cancel", admin_cancel_order_path(order), method: :post %>
     </li>
   <% end %>
 </ul>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% @orders.each do |order| %>
+    <li>
+      <%= link_to "Order ##{order.id}" %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% @orders.each do |order| %>
     <li>
-      <%= link_to "Order ##{order.id}" %>
+      <%= link_to "Order ##{order.id}" %> - Status: <%= order.status %>
     </li>
   <% end %>
 </ul>

--- a/app/views/shared/_order_list.html.erb
+++ b/app/views/shared/_order_list.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% @orders.each do |order| %>
     <li>
-      <%= link_to "Order ##{order.id}" %> - Status: <%= order.status %>
+      <%= link_to "Order ##{order.id}", admin_order_path(order) %> - Status: <%= order.status %>
       <br>
       <%= (render partial: "shared/order_actions", locals: { order: order }) %>
     </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :items, only: [:index, :new, :create]
     get '/dashboard' => 'dashboard#index', as: "dashboard"
+    post '/cancel/order', to: 'orders#cancel', as: :cancel_order
   end
 
   resources :users, only: [:new, :create, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :items, only: [:index, :new, :create]
     get '/dashboard' => 'dashboard#index', as: "dashboard"
-    post '/cancel/order', to: 'orders#cancel', as: :cancel_order
+    post '/modify/order', to: 'orders#modify', as: :modify_order
   end
 
   resources :users, only: [:new, :create, :show] do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:username) { |n| "username_#{n}"}
+    sequence(:password) { |n| "password_#{n}" }
+  end
+end

--- a/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
@@ -26,9 +26,15 @@ describe 'when an admin logs in' do
     expect(page).to have_content(" - Status: #{Order.fourth.status}")
   end
 
-  it "the admin can click 'cancel' on orders that are paid" do
-    click_link "Cancel", href: admin_cancel_order_path(Order.first)
+  it "the admin can click 'cancel' on orders that are ordered" do
+    click_link "Cancel", href: admin_modify_order_path(Order.first, modify_type: "cancel")
 
     expect(page).to have_content("Order ##{Order.first.id} - Status: Cancelled")
+  end
+
+  it "the admin can click 'cancel' on orders that are paid" do
+    click_link "Cancel", href: admin_modify_order_path(Order.second, modify_type: "cancel")
+
+    expect(page).to have_content("Order ##{Order.second.id} - Status: Cancelled")
   end
 end

--- a/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'when an admin logs in' do
+  before(:each) do
+    @category = create(:category)
+    @users = create_list(:user, 2)
+    @items = create_list(:item, 5, category: @category)
+    Order.create(total_price: (@items[0].price * 2), user_id: @users[0].id)
+    Order.create(total_price: (@items[1].price * 3), user_id: @users[0].id, status: 1)
+    Order.create(total_price: (@items[2].price * 2), user_id: @users[0].id, status: 2)
+    Order.create(total_price: (@items[3].price * 2), user_id: @users[1].id, status: 3)
+    @admin = User.create(username: '123', password: "123", role: 1)
+
+    visit root_path
+
+    fill_in 'session[username]', with:'123'
+    fill_in 'session[password]', with: "123"
+
+    click_on("Log In")
+  end
+
+  it "the admin can see the order status of each order" do
+    expect(page).to have_content(" - Status: #{Order.first.status}")
+  end
+
+  it "the admin can click 'cancel' on orders that are paid or ordered" do
+
+  end
+end

--- a/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
@@ -26,15 +26,38 @@ describe 'when an admin logs in' do
     expect(page).to have_content(" - Status: #{Order.fourth.status}")
   end
 
-  it "the admin can click 'cancel' on orders that are ordered" do
+  it "the admin can click 'Cancel' on orders that are ordered" do
     click_link "Cancel", href: admin_modify_order_path(Order.first, modify_type: "cancel")
 
     expect(page).to have_content("Order ##{Order.first.id} - Status: Cancelled")
   end
 
-  it "the admin can click 'cancel' on orders that are paid" do
+  it "the admin can click 'Cancel' on orders that are paid" do
     click_link "Cancel", href: admin_modify_order_path(Order.second, modify_type: "cancel")
 
     expect(page).to have_content("Order ##{Order.second.id} - Status: Cancelled")
+  end
+
+  it "the admin can click 'Mark As Paid' on orders that are ordered" do
+    click_link "Mark As Paid", href: admin_modify_order_path(Order.first, modify_type: "mark as paid")
+
+    expect(page).to have_content("Order ##{Order.first.id} - Status: Paid")
+  end
+
+  it "the admin can click 'Mark As Completed' on orders that are paid" do
+    click_link "Mark As Completed", href: admin_modify_order_path(Order.second, modify_type: "mark as completed")
+
+    expect(page).to have_content("Order ##{Order.second.id} - Status: Completed")
+  end
+
+  it "the admin should not see links for completed and cancelled orders" do
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.third, modify_type: "cancel"))
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.fourth, modify_type: "cancel"))
+
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.third, modify_type: "mark as paid"))
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.fourth, modify_type: "mark as paid"))
+
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.third, modify_type: "mark as completed"))
+    expect(page).not_to have_link(href: admin_modify_order_path(Order.fourth, modify_type: "mark as completed"))
   end
 end

--- a/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_change_order_status_from_dashboard_spec.rb
@@ -21,9 +21,14 @@ describe 'when an admin logs in' do
 
   it "the admin can see the order status of each order" do
     expect(page).to have_content(" - Status: #{Order.first.status}")
+    expect(page).to have_content(" - Status: #{Order.second.status}")
+    expect(page).to have_content(" - Status: #{Order.third.status}")
+    expect(page).to have_content(" - Status: #{Order.fourth.status}")
   end
 
-  it "the admin can click 'cancel' on orders that are paid or ordered" do
+  it "the admin can click 'cancel' on orders that are paid" do
+    click_link "Cancel", href: admin_cancel_order_path(Order.first)
 
+    expect(page).to have_content("Order ##{Order.first.id} - Status: Cancelled")
   end
 end

--- a/spec/features/admin/admin_logs_in_spec.rb
+++ b/spec/features/admin/admin_logs_in_spec.rb
@@ -1,8 +1,16 @@
 require 'rails_helper'
 
 describe 'when an admin logs in' do
-  it 'is redirected to admin dashboard' do
-    admin = User.create(username: '123', password: "123", role: 1)
+  before(:each) do
+    @category = create(:category)
+    @users = create_list(:user, 2)
+    @items = create_list(:item, 5, category: @category)
+    Order.create(total_price: (@items[0].price * 2), user_id: @users[0].id)
+    Order.create(total_price: (@items[1].price * 3), user_id: @users[0].id)
+    Order.create(total_price: (@items[2].price * 2), user_id: @users[0].id)
+    Order.create(total_price: (@items[3].price * 2), user_id: @users[1].id)
+    Order.create(total_price: (@items[4].price * 2), user_id: @users[1].id)
+    @admin = User.create(username: '123', password: "123", role: 1)
 
     visit root_path
 
@@ -10,8 +18,17 @@ describe 'when an admin logs in' do
     fill_in 'session[password]', with: "123"
 
     click_on("Log In")
+  end
 
+  it 'is redirected to admin dashboard' do
     expect(current_path).to eq(admin_dashboard_path)
+  end
 
+ it "the admin sees a listing of all orders" do
+    expect(page).to have_link("Order ##{Order.first.id}")
+    expect(page).to have_link("Order ##{Order.second.id}")
+    expect(page).to have_link("Order ##{Order.third.id}")
+    expect(page).to have_link("Order ##{Order.fourth.id}")
+    expect(page).to have_link("Order ##{Order.fifth.id}")
   end
 end

--- a/spec/features/admin/admin_logs_in_spec.rb
+++ b/spec/features/admin/admin_logs_in_spec.rb
@@ -6,9 +6,9 @@ describe 'when an admin logs in' do
     @users = create_list(:user, 2)
     @items = create_list(:item, 5, category: @category)
     Order.create(total_price: (@items[0].price * 2), user_id: @users[0].id)
-    Order.create(total_price: (@items[1].price * 3), user_id: @users[0].id)
-    Order.create(total_price: (@items[2].price * 2), user_id: @users[0].id)
-    Order.create(total_price: (@items[3].price * 2), user_id: @users[1].id)
+    Order.create(total_price: (@items[1].price * 3), user_id: @users[0].id, status: 1)
+    Order.create(total_price: (@items[2].price * 2), user_id: @users[0].id, status: 2)
+    Order.create(total_price: (@items[3].price * 2), user_id: @users[1].id, status: 3)
     Order.create(total_price: (@items[4].price * 2), user_id: @users[1].id)
     @admin = User.create(username: '123', password: "123", role: 1)
 
@@ -30,5 +30,12 @@ describe 'when an admin logs in' do
     expect(page).to have_link("Order ##{Order.third.id}")
     expect(page).to have_link("Order ##{Order.fourth.id}")
     expect(page).to have_link("Order ##{Order.fifth.id}")
+  end
+
+  it "the admin sees links to filter orders by status type" do
+    expect(page).to have_link("Ordered")
+    expect(page).to have_link("Paid")
+    expect(page).to have_link("Cancelled")
+    expect(page).to have_link("Completed")
   end
 end

--- a/spec/features/admin/admin_logs_in_spec.rb
+++ b/spec/features/admin/admin_logs_in_spec.rb
@@ -38,4 +38,44 @@ describe 'when an admin logs in' do
     expect(page).to have_link("Cancelled")
     expect(page).to have_link("Completed")
   end
+
+  it "the admin can click on 'Ordered' to see only orders of that type" do
+    click_link "Ordered"
+
+    expect(page).to have_link("Order ##{Order.first.id}")
+    expect(page).not_to have_link("Order ##{Order.second.id}")
+    expect(page).not_to have_link("Order ##{Order.third.id}")
+    expect(page).not_to have_link("Order ##{Order.fourth.id}")
+    expect(page).to have_link("Order ##{Order.fifth.id}")
+  end
+
+  it "the admin can click on 'Paid' to see only orders of that type" do
+    click_link "Paid"
+
+    expect(page).not_to have_link("Order ##{Order.first.id}")
+    expect(page).to have_link("Order ##{Order.second.id}")
+    expect(page).not_to have_link("Order ##{Order.third.id}")
+    expect(page).not_to have_link("Order ##{Order.fourth.id}")
+    expect(page).not_to have_link("Order ##{Order.fifth.id}")
+  end
+
+  it "the admin can click on 'Cancelled' to see only orders of that type" do
+    click_link "Cancelled"
+
+    expect(page).not_to have_link("Order ##{Order.first.id}")
+    expect(page).not_to have_link("Order ##{Order.second.id}")
+    expect(page).to have_link("Order ##{Order.third.id}")
+    expect(page).not_to have_link("Order ##{Order.fourth.id}")
+    expect(page).not_to have_link("Order ##{Order.fifth.id}")
+  end
+
+  it "the admin can click on 'Completed' to see only orders of that type" do
+    click_link "Completed"
+
+    expect(page).not_to have_link("Order ##{Order.first.id}")
+    expect(page).not_to have_link("Order ##{Order.second.id}")
+    expect(page).not_to have_link("Order ##{Order.third.id}")
+    expect(page).to have_link("Order ##{Order.fourth.id}")
+    expect(page).not_to have_link("Order ##{Order.fifth.id}")
+  end
 end


### PR DESCRIPTION
Fixes/Addresses: #72 

Changes made: 
after admin logs in, they
 - can see all orders in their dashboard
      - order links do not lead anywhere at the moment, awaiting merge
 - can filter orders by status type
 - can change the status of order from dashboard 

@Tyjoo26 @erikaannesmith 
