### PR TITLE
admin can only edit self

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,7 @@ class Admin::DashboardController < Admin::BaseController
 
   def index
     @orders = choose_orders
+    @user = current_user
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,11 @@ class UsersController < ApplicationController
     user = User.find(params[:id])
     user.update(user_params)
 
-    redirect_to dashboard_path
+    if current_user.admin?
+      redirect_to admin_dashboard_path
+    else
+      redirect_to dashboard_path
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
 
   def edit
     @user = User.find(params[:id])
+    return render_404 if @user != current_user
   end
 
   def update

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,6 +1,7 @@
 <h4 id= "admin_dash_header">Admin Dashboard</h4>
 
 <%= link_to "All Items", admin_items_path %>
+<p><%= link_to "Edit Account", edit_user_path(@user) %></p>
 
 <% @orders.status_types.each do |type| %>
   <span id='order_type'><%= link_to type, admin_dashboard_path(order_type: type) %></span>

--- a/spec/features/admin/admin_can_edit_their_own_information_spec.rb
+++ b/spec/features/admin/admin_can_edit_their_own_information_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "When an admin signs in" do
+
+  before(:each) do
+    @admin = User.create(username: "admin",
+                        password: "password",
+                        full_name: "Admin Person",
+                        address: "2020 Longest Rd, Denver, CO",
+                        role: 1)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+    visit admin_dashboard_path
+  end
+
+  describe "clicks 'Edit Account', changes information, and clicks Update User" do
+    it "the admin has changed their own information" do
+      click_link("Edit Account")
+
+      expect(current_path).to eq(edit_user_path(@admin))
+      fill_in "user[username]", with: "new_name"
+      fill_in "user[password]", with: "new_password"
+      fill_in "user[full_name]", with: "New Name"
+      fill_in "user[address]", with: "1 Market St., Denver, CO"
+
+      click_button "Update User"
+
+      expect(User.last.username).to eq("new_name")
+      expect(User.last.full_name).to eq("New Name")
+      expect(User.last.address).to eq("1 Market St., Denver, CO")
+      expect(current_path).to eq(admin_dashboard_path)
+    end
+  end
+end

--- a/spec/features/admin/admin_can_edit_their_own_information_spec.rb
+++ b/spec/features/admin/admin_can_edit_their_own_information_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 describe "When an admin signs in" do
 
   before(:each) do
+    @user = User.create(username: "default_person_1",
+                        password: "password",
+                        full_name: "Default Person",
+                        address: "2020 Longest Rd, Denver, CO")
     @admin = User.create(username: "admin",
                         password: "password",
                         full_name: "Admin Person",
@@ -31,5 +35,11 @@ describe "When an admin signs in" do
       expect(User.last.address).to eq("1 Market St., Denver, CO")
       expect(current_path).to eq(admin_dashboard_path)
     end
+  end
+
+  it "the admin cannot edit another user's information" do
+    visit edit_user_path(@user)
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
   end
 end

--- a/spec/features/users/authenticated_user_can_edit_self_spec.rb
+++ b/spec/features/users/authenticated_user_can_edit_self_spec.rb
@@ -3,11 +3,14 @@ require 'rails_helper'
 describe "When an authenticated user visits their dashboard" do
 
   before(:each) do
+    @user_1 = User.create(username: "default_person_2",
+                        password: "password",
+                        full_name: "Default Person2",
+                        address: "2020 Longest Rd, Denver, CO")
     @user = User.create(username: "default_person_1",
                         password: "password",
                         full_name: "Default Person",
                         address: "2020 Longest Rd, Denver, CO")
-
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
 
@@ -35,5 +38,11 @@ describe "When an authenticated user visits their dashboard" do
     expect(User.last.full_name).to eq("New Name")
     expect(User.last.address).to eq("1 Market St., Denver, CO")
     expect(current_path).to eq(dashboard_path)
+  end
+
+  it "the user cannot edit other user's information" do
+    visit edit_user_path(@user_1)
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
   end
 end


### PR DESCRIPTION
Fixes/Addresses: #81 

Changes made: 
 - admin can edit own information
 - admin cannot edit another user's information (sees cannot find page)

@Tyjoo26 @icorson3 
