### PR TITLE
link added to admin dash for creating a new item

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -2,6 +2,7 @@
 
 <%= link_to "All Items", admin_items_path %>
 <p><%= link_to "Edit Account", edit_user_path(@user) %></p>
+<p><%= link_to "Create Item", new_admin_item_path %></p>
 
 <% @orders.status_types.each do |type| %>
   <span id='order_type'><%= link_to type, admin_dashboard_path(order_type: type) %></span>

--- a/spec/features/admin/admin_can_create_a_new_item_spec.rb
+++ b/spec/features/admin/admin_can_create_a_new_item_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
-describe "When an admin visits 'admin/items/new', enters item information, and clicks Create Item" do
+describe "When an admin visits dashboard, clicks Create Item, enters item information, and clicks Create Item" do
   it "the admin has created a new item" do
     category = create(:category)
     admin = User.create(username: "admin", password: "password", role: 1)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-    visit new_admin_item_path
+    visit admin_dashboard_path
+
+    click_link "Create Item"
 
     fill_in "item[title]", with: "Item 1"
     fill_in "item[description]", with: "This is an awesome item."

--- a/spec/features/admin/admin_sees_dashboard_spec.rb
+++ b/spec/features/admin/admin_sees_dashboard_spec.rb
@@ -9,7 +9,7 @@ describe 'when an admin logs in and visits admin dashboard' do
       visit admin_dashboard_path
 
       expect(page).to have_content("Admin Dashboard")
-
+      expect(page).to have_link("Create Item")
     end
 
     scenario 'when a registered user tries to access admin dashboard they get a 404' do


### PR DESCRIPTION
Fixes/Addresses: #102 

Changes made: 
 - Admin Dashboard has "Create Item" link
 - Test that admin can use link to create item
 -

@Tyjoo26 @erikaannesmith 